### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+src/blacklist.txt
+src/optin.txt
+target/


### PR DESCRIPTION
The list of users that are opted/blacklisted should probably not be public, so it's in the .gitignore file now. Similarly the target folder is build artifacts and doesn't need to be uploaded.